### PR TITLE
Bookmark aggregation pipeline

### DIFF
--- a/remarkable/src/components/SearchBar.tsx
+++ b/remarkable/src/components/SearchBar.tsx
@@ -44,7 +44,7 @@ export default function SearchBar() {
           <ul>
             {bookmarks.map(bookmark => (
               <li key={bookmark._id}>
-                <a href={bookmark.url}>{`${bookmark.title}- ${bookmark.url}`}</a>
+                <a href={bookmark.url} target='_blank'>{`${bookmark.title}- ${bookmark.url}`}</a>
               </li>
             ))}
           </ul>

--- a/remarkable/src/pages/api/getBookmarks.ts
+++ b/remarkable/src/pages/api/getBookmarks.ts
@@ -31,14 +31,6 @@ export default async function createBookmark(req: NextApiRequest, res: NextApiRe
       }
     },
     {
-      $lookup: {
-        from: "tags",
-        localField: "tags",
-        foreignField: "_id",
-        as: "tags"
-      }
-    },
-    {
       $addFields: {
         relevance: { $size: { $setIntersection: ["$tags", tagIds] } }
       }
@@ -47,7 +39,7 @@ export default async function createBookmark(req: NextApiRequest, res: NextApiRe
       $group: {
         _id: { _id: "$_id", title: "$title" },
         url: { $first: "$url" },
-        tags: { $addToSet: "$tags.name" },
+        tags: { $addToSet: "$tags" },
         relevance: { $max: "$relevance" }
       }
     },
@@ -65,7 +57,7 @@ export default async function createBookmark(req: NextApiRequest, res: NextApiRe
         relevance: -1
       }
     }
-  ]);
+  ])
 
   console.log('BOOKMARKS: ', bookmarks)
 


### PR DESCRIPTION
This pipeline gets bookmarks that have tags associated with the search tags, and sorts them by relevancy (number of tags in common). Currently this pipeline sends back tag ids to the front end instead of tag names.