### PR TITLE
Fix duplicate status code

### DIFF
--- a/remarkable/src/components/BookmarkForm.tsx
+++ b/remarkable/src/components/BookmarkForm.tsx
@@ -37,8 +37,7 @@ export default function BookmarkForm() {
       })
       .catch(err => {
         console.log(err)
-        if(err.response.data.code === 11000) setFieldError('url', 'Bookmark already exists');
-        else setErrorMessage('Bookmark could not be created at this time');
+        setFieldError('url', err.response.data.message);
       });
   }
 

--- a/remarkable/src/pages/api/createBookmark.ts
+++ b/remarkable/src/pages/api/createBookmark.ts
@@ -9,6 +9,9 @@ export default async function createBookmark(req: NextApiRequest, res: NextApiRe
 
   const { url, title, tags } = req.body;
 
+  const existingBookmark = await Bookmark.findOne({ url });
+  if(existingBookmark) return res.status(409).json({ message: 'Bookmark already exists' });
+
   const tagIds = await Promise.all(tags.map(async (tag: String) => {
     const existingTag = await Tag.findOne({ name: tag});
     if(existingTag) return existingTag._id;
@@ -21,8 +24,7 @@ export default async function createBookmark(req: NextApiRequest, res: NextApiRe
     res.status(201).send('Bookmark created!');
   } catch(err) {
     console.error('ERR:', err);
-    if(err.code === 11000) return res.status(409).json({message: 'Bookmark already exists'});
-    res.status(500).send({message: 'Bookmark was unable to be created at this time'});
+    res.status(500).send({ message: 'Bookmark was unable to be created at this time' });
   }
 
 

--- a/remarkable/src/pages/api/createBookmark.ts
+++ b/remarkable/src/pages/api/createBookmark.ts
@@ -21,8 +21,8 @@ export default async function createBookmark(req: NextApiRequest, res: NextApiRe
     res.status(201).send('Bookmark created!');
   } catch(err) {
     console.error('ERR:', err);
-    //const message = err.code === 11000 ? 'Bookmark already exists' : 'Bookmark was unable to be created at this time'
-    res.status(500).send({code: err.code});
+    if(err.code === 11000) return res.status(409).json({message: 'Bookmark already exists'});
+    res.status(500).send({message: 'Bookmark was unable to be created at this time'});
   }
 
 

--- a/remarkable/tsconfig.json
+++ b/remarkable/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "useUnknownInCatchVariables": false,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Instead of sending the mongo error code for duplicate record, 409 will be sent with appropriate error message